### PR TITLE
Add option to change ingress and storage class

### DIFF
--- a/deployment/helm/templates/elasticsearch_statefulset.yaml
+++ b/deployment/helm/templates/elasticsearch_statefulset.yaml
@@ -19,6 +19,9 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
+        {{- if .Values.applications.es.storageClassName }}
+        storageClassName: {{ .Values.applications.es.storageClassName }}
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.applications.es.storage }}

--- a/deployment/helm/templates/nginx_ingress.yaml
+++ b/deployment/helm/templates/nginx_ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     {{ end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Values.ingressClassName | default "nginx" }}
   rules:
     - host: {{ .Values.domainName }}
       http:

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -96,6 +96,8 @@ applications:
     cluster:
       initial_master_nodes: elasticsearch-0
     storage: 5Gi
+    # -- Optionally configure a storage class to use for the pvc, otherwise uses default storage class
+    # storageClassName: 
     resources:
       limits:
         # -- Maximum CPU resource units(1 CPU unit is equivalent to 1 physical CPU core, or 1 virtual core)
@@ -149,3 +151,5 @@ applications:
       key: "AP-BCBBKBNAYWW6-2-2"
 domainName: my-control-plane
 imagePullSecretName: regcred
+# -- Optionally configure a ingress class to use for the kubernetes ingress (default: nginx)
+# ingressClassName: nginx


### PR DESCRIPTION
In order to deploy in certain cloud hosted kubernetes environments a specific ingress class is needed and the default storage class may not be compatible with elasticsearch - this exposes those settings as values.