### PR TITLE
fix: nginx port to match service when sslEnabled

### DIFF
--- a/deployment/helm/templates/nginx_ingress.yaml
+++ b/deployment/helm/templates/nginx_ingress.yaml
@@ -21,4 +21,8 @@ spec:
               service: 
                 name: {{ .Values.applications.ingress.name }}-svc
                 port: 
-                  number: 8080            
+                  {{- if eq .Values.applications.ingress.sslEnabled true }}
+                  number: 8443
+                  {{- else }}
+                  number: 8080
+                  {{- end }}


### PR DESCRIPTION
Currently the nginx ingress is hardcoded to talk to port 8080 on the ingress service - where as the ingress service changes from port 8080 to 8443 when sslEnabled is true. 

This adds the same logic to the nginx ingress so that the ports match