### PR TITLE
Update replica for ES as 3

### DIFF
--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -91,7 +91,7 @@ applications:
     # -- Elasticsearch image tag
     imageTag: "8.1.1"
     # -- Storage size for persistent volume
-    replicas: 1
+    replicas: 3
     # -- Cluster master nodes in the format "<name>-0, ..., <name>-(n-1)" where n is replicas. For a single node cluster it will be "<name>-0".
     cluster:
       initial_master_nodes: elasticsearch-0


### PR DESCRIPTION
If we have only one ES, then ILM will not work. This is because replica at index level is configured as 2 and when only one node is present, the health of shards and index will be YELLOW which will cause disruption in ILM